### PR TITLE
Feat(gcp): Optimizar Dockerfile para Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ ENV PYTHONPATH=/app
 # Exponer el puerto
 EXPOSE 8080
 
-# Comando para ejecutar la aplicación
-CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "120", "app:app"]
+# Comando para ejecutar la aplicación, optimizado para Cloud Run
+# Se recomienda 1 worker y gestionar la concurrencia a nivel de instancia.
+# Threads puede ser ajustado según la naturaleza de la carga (I/O vs CPU bound).
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "1", "--threads", "8", "--timeout", "0", "app:app"]
 


### PR DESCRIPTION
- Ajusta el comando de Gunicorn para usar 1 worker y 8 hilos, siguiendo las mejores prácticas para Cloud Run.
- Establece el timeout en 0 para permitir que Cloud Run gestione los tiempos de espera de las solicitudes.